### PR TITLE
Add UnreadablePublicationStatusCheck (fixes #20)

### DIFF
--- a/docs/embedded-tests.md
+++ b/docs/embedded-tests.md
@@ -20,6 +20,7 @@
   * [TemplatesIndexationCheck](#templatesindexationcheck)
   * [UndeclaredNodeTypesCheck](#undeclarednodetypescheck)
   * [UndeployedModulesReferencesCheck](#undeployedmodulesreferencescheck)
+  * [UnreadablePublicationStatusCheck](#unreadablepublicationstatuscheck)
   * [UserAccountSanityCheck](#useraccountsanitycheck)
   * [VersionHistoryCheck](#versionhistorycheck)
   * [VersionsSanityCheck](#versionsanitycheck)
@@ -527,6 +528,44 @@ If the module was undeployed for good reasons, then you need to clean the site n
 
     root@dx()> jcr:cd /sites/digitall
     root@dx()> jcr:prop-set -multiple -op remove j:installedModules myOldModule 
+
+## UnreadablePublicationStatusCheck
+
+Detects `jmix:i18n` nodes for which the workflow and delete status cannot be read by the publication service.
+
+When computing publication info, `ComplexPublicationServiceImpl` calls `session.getNodeByUUID(uuid)` on a locale-specific session for each language a node is translated into. If the node's path cannot be resolved in that locale (typically because the node or one of its ancestors is missing the corresponding translation sub-node), Jahia throws a `PathNotFoundException` wrapped as an `ItemNotFoundException`, and logs the warning:
+
+```
+Issue when reading workflow and delete status of node <path>
+```
+
+This check replicates that lookup: for every `j:translation_<lang>` child found on an `jmix:i18n` node, it attempts to load the parent node by identifier via a locale-specific system session. A failure is reported as an integrity error. The check runs on both the `default` and `live` workspaces.
+
+### Dealing with errors
+
+`Error code: UNREADABLE_PUBLICATION_STATUS`
+
+**Description**: The node has a `j:translation_<lang>` child but cannot be loaded via a localized JCR session for that language. This blocks the publication service from computing the publication status of the node and its subtree.
+
+The root cause is usually one of the following:
+
+- An ancestor of the reported node has `jmix:i18n` but is missing the translation for the affected language (e.g. the ancestor's `j:translation_<lang>` was deleted while the descendant's was not, or vice-versa).
+- A database or datastore failure partially wrote or deleted a translation node, leaving the tree in an inconsistent state.
+
+To fix the issue, identify which node in the path is missing its translation for the reported locale. Then either:
+
+- Restore the missing translation node (recreate `j:translation_<lang>` on the ancestor and republish).
+- Or, if the orphaned translation sub-node on the reported node is the cause, delete it.
+
+In the `live` workspace, deleting the problematic node or its orphaned translation directly via a Groovy script is often the quickest way to unblock publication:
+
+```groovy
+def session = org.jahia.services.content.JCRSessionFactory.getInstance()
+                  .getCurrentSystemSession("live", null, null)
+def node = session.getNode("/sites/mySite/path/to/node")
+node.remove()
+session.save()
+```
 
 ## UserAccountSanityCheck
 

--- a/src/main/java/org/jahia/modules/contentintegrity/services/checks/UnreadablePublicationStatusCheck.java
+++ b/src/main/java/org/jahia/modules/contentintegrity/services/checks/UnreadablePublicationStatusCheck.java
@@ -1,0 +1,61 @@
+package org.jahia.modules.contentintegrity.services.checks;
+
+import org.jahia.modules.contentintegrity.api.ContentIntegrityCheck;
+import org.jahia.modules.contentintegrity.api.ContentIntegrityErrorList;
+import org.jahia.modules.contentintegrity.api.ContentIntegrityErrorType;
+import org.jahia.modules.contentintegrity.services.impl.AbstractContentIntegrityCheck;
+import org.jahia.modules.contentintegrity.services.impl.JCRUtils;
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.content.JCRSessionWrapper;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+
+import static org.jahia.modules.contentintegrity.services.impl.Constants.JAHIA_MIX_I18N;
+import static org.jahia.modules.contentintegrity.services.impl.Constants.TRANSLATION_NODE_PREFIX;
+
+@Component(service = ContentIntegrityCheck.class, immediate = true, property = {
+        ContentIntegrityCheck.ExecutionCondition.APPLY_ON_NT + "=" + JAHIA_MIX_I18N
+})
+public class UnreadablePublicationStatusCheck extends AbstractContentIntegrityCheck {
+
+    private static final Logger logger = LoggerFactory.getLogger(UnreadablePublicationStatusCheck.class);
+
+    public static final ContentIntegrityErrorType UNREADABLE_PUBLICATION_STATUS =
+            createErrorType("UNREADABLE_PUBLICATION_STATUS",
+                    "Issue when reading workflow and delete status of node");
+
+    @Override
+    public ContentIntegrityErrorList checkIntegrityBeforeChildren(JCRNodeWrapper node) {
+        try {
+            final ContentIntegrityErrorList errors = createEmptyErrorsList();
+            final String nodeId = node.getIdentifier();
+            final NodeIterator translationNodes = node.getNodes(TRANSLATION_NODE_PREFIX + "*");
+
+            while (translationNodes.hasNext()) {
+                final Node translationNode = translationNodes.nextNode();
+                final String locale = JCRUtils.getTranslationNodeLocale(translationNode);
+                if (locale == null) continue;
+
+                final JCRSessionWrapper localizedSession = JCRUtils.getSystemSession(node.getSession(), locale);
+                if (localizedSession == null) continue;
+
+                try {
+                    localizedSession.getNodeByIdentifier(nodeId);
+                } catch (ItemNotFoundException e) {
+                    errors.addError(createError(node, locale, UNREADABLE_PUBLICATION_STATUS)
+                            .addExtraInfo("locale", locale, true));
+                }
+            }
+
+            return errors;
+        } catch (RepositoryException e) {
+            return createSingleError(createFrameworkError(node, e));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `UnreadablePublicationStatusCheck`, a new integrity check targeting all `jmix:i18n` nodes in both DEFAULT and LIVE workspaces.
- For each `j:translation_<lang>` child found, the check attempts to load the parent node by UUID via a locale-specific system session. An `ItemNotFoundException` (wrapping `PathNotFoundException` from `JCRStoreProvider.createWrapper`) is reported as an integrity error, matching exactly the warning `ComplexPublicationServiceImpl` emits: _"Issue when reading workflow and delete status of node"_.
- The error is reported per locale with the affected locale stored as extra info.

Closes #20

## Context

Observed on Jahia 8.1.6.1 (TGCDSUPPORT-6162). A `j:conditionalVisibility` node existed in LIVE under a content node whose English translation had been lost (likely due to a database failure). `ComplexPublicationServiceImpl.convert()` calls `session.getNodeByUUID(uuid)` with a localized session; when the node's path cannot be resolved in the requested locale, `JCRStoreProvider.createWrapper()` throws `PathNotFoundException`, wrapped as `ItemNotFoundException`. This blocked all publish/unpublish operations on the affected page until the orphaned node was manually deleted from LIVE.

## Test plan

- [ ] Run the check on a site where all `jmix:i18n` nodes have consistent translations → no errors reported.
- [ ] Manually create an `jmix:i18n` node with a `j:translation_en` child, then corrupt the state so the node cannot be resolved in the `en` localized session → error `UNREADABLE_PUBLICATION_STATUS` is reported for locale `en`.
- [ ] Verify the check runs on both DEFAULT and LIVE workspaces.
- [ ] Confirm that fixing the underlying cause (restoring the missing translation or removing the orphaned node) makes the error disappear on the next scan.
